### PR TITLE
feat(auth): expose Google idToken for backend authentication

### DIFF
--- a/packages/core/src/sdk/baseClient.ts
+++ b/packages/core/src/sdk/baseClient.ts
@@ -466,19 +466,23 @@ export class BaseClient implements ISDKFacade {
 
   /**
    * Login with Google
-   * @returns The access token, whether the user has a backup and the user data from Google
+   * @returns The Google access token for Google APIs, the Google ID token for backend auth, whether the user has a backup and the user data from Google
+   * @see {@link https://developers.google.com/identity/sign-in/web/backend-auth | Authenticate with a backend server (ID token)}
    */
   async loginWithGoogle(): Promise<{
     accessToken: string
+    idToken: string
     hasBackup: boolean
     userData: User | undefined
   }> {
     try {
-      const { accessToken, user } = await this.authenticationManager.signIn()
+      const { accessToken, idToken, user } =
+        await this.authenticationManager.signIn()
       this.backupManager.updateAccessToken(accessToken)
       const hasBackup = await this.backupManager.hasWalletBackup()
       return {
         accessToken,
+        idToken,
         hasBackup,
         userData: user,
       }

--- a/packages/core/src/shared/interfaces/IAuth.ts
+++ b/packages/core/src/shared/interfaces/IAuth.ts
@@ -1,8 +1,16 @@
 import { User } from '../types/backupTypes'
 
 export interface IAuthentication {
-  signIn(): Promise<{ accessToken: string; user: User | undefined }>
+  signIn(): Promise<{
+    accessToken: string
+    idToken: string
+    user: User | undefined
+  }>
   signOut(): Promise<void>
   getAccessToken(oldAccessToken: string): Promise<string>
-  signInSilently(): Promise<{ accessToken: string; user: User | undefined }>
+  signInSilently(): Promise<{
+    accessToken: string
+    idToken: string
+    user: User | undefined
+  }>
 }

--- a/packages/core/src/shared/interfaces/ISDKFacade.ts
+++ b/packages/core/src/shared/interfaces/ISDKFacade.ts
@@ -9,6 +9,7 @@ import { NetworkType, User, Wallet, WalletAccount } from '../types/backupTypes'
 export interface ISDKFacade {
   loginWithGoogle(): Promise<{
     accessToken: string
+    idToken: string
     hasBackup: boolean
     userData: User | undefined
   }>

--- a/packages/core/src/shared/types/backupTypes.ts
+++ b/packages/core/src/shared/types/backupTypes.ts
@@ -61,7 +61,9 @@ export type User = {
   }
   scopes: string[]
   /**
-   * JWT (JSON Web Token) that serves as a secure credential for your user's identity.
+   * JWT from the Google Sign-In user profile (e.g. React Native `GoogleSignin` user snapshot).
+   * Separate from the top-level `idToken` returned by `loginWithGoogle()` / `IAuthentication.signIn()`,
+   * which is the OIDC `id_token` from the OAuth token response for backend verification.
    */
   idToken: string | null
   /**

--- a/packages/core/testing/__mocks__/managers/managers.ts
+++ b/packages/core/testing/__mocks__/managers/managers.ts
@@ -9,9 +9,14 @@ import { IEncryptionManager } from '../../../src/shared/interfaces/IEncryption'
 
 export const authenticationManager: IAuthentication = {
   signIn: jest.fn(
-    async (): Promise<{ accessToken: string; user: User | undefined }> => {
+    async (): Promise<{
+      accessToken: string
+      idToken: string
+      user: User | undefined
+    }> => {
       return {
         accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
         user: {
           user: {
             id: 'mock-user-id',
@@ -33,9 +38,14 @@ export const authenticationManager: IAuthentication = {
   }),
   getAccessToken: jest.fn(),
   signInSilently: jest.fn(
-    async (): Promise<{ accessToken: string; user: User | undefined }> => {
+    async (): Promise<{
+      accessToken: string
+      idToken: string
+      user: User | undefined
+    }> => {
       return {
         accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
         user: {
           user: {
             id: 'mock-user-id',

--- a/packages/core/testing/__tests__/sdk/baseClient.test.ts
+++ b/packages/core/testing/__tests__/sdk/baseClient.test.ts
@@ -90,12 +90,14 @@ describe('BaseClient', () => {
       }
       jest.spyOn(authenticationManager, 'signIn').mockResolvedValueOnce({
         accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
         user: mockUser,
       })
       jest.spyOn(backupManager, 'hasWalletBackup').mockResolvedValueOnce(true)
       const result = await baseClient.loginWithGoogle()
       expect(result).toEqual({
         accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
         hasBackup: true,
         userData: mockUser,
       })
@@ -128,6 +130,7 @@ describe('BaseClient', () => {
       }
       jest.spyOn(authenticationManager, 'signIn').mockResolvedValueOnce({
         accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
         user: mockUser,
       })
       jest

--- a/packages/extension/src/authentication/authenticationManager.ts
+++ b/packages/extension/src/authentication/authenticationManager.ts
@@ -16,8 +16,12 @@ export class AuthenticationManager implements IAuthentication {
     private storageManager: IStorageManager
   ) {}
 
-  async signIn(): Promise<{ accessToken: string; user: User | undefined }> {
-    const { accessToken, refreshToken } =
+  async signIn(): Promise<{
+    accessToken: string
+    idToken: string
+    user: User | undefined
+  }> {
+    const { accessToken, refreshToken, idToken } =
       await this.googleSignInClient.loginWithGoogle(
         this.googleClientId,
         this.googleClientSecret,
@@ -25,7 +29,7 @@ export class AuthenticationManager implements IAuthentication {
         this.scopes
       )
     await this.storageManager.setItem('refreshToken', refreshToken)
-    return { accessToken, user: undefined }
+    return { accessToken, idToken: idToken || '', user: undefined }
   }
 
   /**
@@ -49,6 +53,7 @@ export class AuthenticationManager implements IAuthentication {
 
   async signInSilently(): Promise<{
     accessToken: string
+    idToken: string
     user: User | undefined
   }> {
     const storedRefreshToken =
@@ -63,6 +68,7 @@ export class AuthenticationManager implements IAuthentication {
         this.googleClientSecret,
         storedRefreshToken
       ),
+      idToken: '',
       user: undefined,
     }
   }

--- a/packages/extension/src/authentication/googleSignInClient.ts
+++ b/packages/extension/src/authentication/googleSignInClient.ts
@@ -42,7 +42,7 @@ export class GoogleSigninClient implements IGoogleSignInClient {
     googleClientSecret: string,
     redirectUri: string,
     scopes: string[]
-  ): Promise<{ accessToken: string; refreshToken: string }> {
+  ): Promise<{ accessToken: string; refreshToken: string; idToken?: string }> {
     const authUrl = new URL(AUTHENTICATION_URL)
     authUrl.searchParams.set('client_id', googleClientId)
     authUrl.searchParams.set('response_type', 'code')
@@ -106,6 +106,7 @@ export class GoogleSigninClient implements IGoogleSignInClient {
     return {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token,
+      idToken: tokens.id_token || '',
     }
   }
 
@@ -163,6 +164,7 @@ export class GoogleSigninClient implements IGoogleSignInClient {
   ): Promise<{
     access_token: string
     refresh_token: string
+    id_token?: string
     expires_at: number
     salt: string
   }> {
@@ -198,6 +200,7 @@ export class GoogleSigninClient implements IGoogleSignInClient {
     return {
       access_token: tokens.access_token,
       refresh_token: tokens.refresh_token,
+      id_token: tokens.id_token,
       expires_at: expiresAt,
       salt: '',
     }

--- a/packages/extension/src/interfaces/IGoogleSignInClient.ts
+++ b/packages/extension/src/interfaces/IGoogleSignInClient.ts
@@ -4,7 +4,7 @@ export interface IGoogleSignInClient {
     googleClientSecret: string,
     redirectUri: string,
     scopes: string[]
-  ): Promise<{ accessToken: string; refreshToken: string }>
+  ): Promise<{ accessToken: string; refreshToken: string; idToken?: string }>
 
   getAccessToken(
     googleClientId: string,

--- a/packages/extension/testing/__tests__/authentication/authenticationManager.test.ts
+++ b/packages/extension/testing/__tests__/authentication/authenticationManager.test.ts
@@ -46,12 +46,14 @@ describe('Authentication manager unit tests', () => {
       mockGoogleSignInClient.loginWithGoogle.mockResolvedValueOnce({
         accessToken,
         refreshToken,
+        idToken: 'mock-id-token',
       })
 
       const result = await authenticationManager.signIn()
 
       expect(result).toEqual({
         accessToken,
+        idToken: 'mock-id-token',
         user: undefined,
       })
       expect(mockGoogleSignInClient.loginWithGoogle).toHaveBeenCalledWith(
@@ -81,6 +83,7 @@ describe('Authentication manager unit tests', () => {
       mockGoogleSignInClient.loginWithGoogle.mockResolvedValueOnce({
         accessToken,
         refreshToken,
+        idToken: 'mock-id-token',
       })
 
       await customManager.signIn()
@@ -225,6 +228,7 @@ describe('Authentication manager unit tests', () => {
 
       expect(result).toEqual({
         accessToken: newAccessToken,
+        idToken: '',
         user: undefined,
       })
       expect(mockGoogleSignInClient.getAccessToken).toHaveBeenCalledWith(
@@ -326,10 +330,12 @@ describe('Authentication manager unit tests', () => {
       mockGoogleSignInClient.loginWithGoogle.mockResolvedValueOnce({
         accessToken,
         refreshToken,
+        idToken: 'mock-id-token',
       })
       const signInResult = await authenticationManager.signIn()
       expect(signInResult).toEqual({
         accessToken,
+        idToken: 'mock-id-token',
         user: undefined,
       })
 
@@ -356,6 +362,7 @@ describe('Authentication manager unit tests', () => {
       mockGoogleSignInClient.loginWithGoogle.mockResolvedValueOnce({
         accessToken,
         refreshToken,
+        idToken: 'mock-id-token',
       })
       await authenticationManager.signIn()
 
@@ -368,6 +375,7 @@ describe('Authentication manager unit tests', () => {
       const silentResult = await authenticationManager.signInSilently()
       expect(silentResult).toEqual({
         accessToken: newAccessToken,
+        idToken: '',
         user: undefined,
       })
     })

--- a/packages/extension/testing/__tests__/authentication/googleClient.test.ts
+++ b/packages/extension/testing/__tests__/authentication/googleClient.test.ts
@@ -170,6 +170,7 @@ describe('Google client unit tests', () => {
       expect(result).toEqual({
         accessToken: 'test-access-token',
         refreshToken: 'test-refresh-token',
+        idToken: '',
       })
       expect(mockLaunchWebAuthFlow).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/mobile/src/auth/googleAuth.ts
+++ b/packages/mobile/src/auth/googleAuth.ts
@@ -30,6 +30,7 @@ export class GoogleAuth implements IAuthentication {
 
   async signInSilently(): Promise<{
     accessToken: string
+    idToken: string
     user: User | undefined
   }> {
     try {
@@ -37,9 +38,10 @@ export class GoogleAuth implements IAuthentication {
       if (!signInResponse.data) {
         throw new SignInRequiredError()
       }
-      const { accessToken } = await GoogleSignin.getTokens()
+      const { accessToken, idToken } = await GoogleSignin.getTokens()
       return {
         accessToken,
+        idToken,
         user: signInResponse.data,
       }
     } catch (error) {
@@ -70,16 +72,21 @@ export class GoogleAuth implements IAuthentication {
     }
   }
 
-  async signIn(): Promise<{ accessToken: string; user: User | undefined }> {
+  async signIn(): Promise<{
+    accessToken: string
+    idToken: string
+    user: User | undefined
+  }> {
     try {
       await GoogleSignin.hasPlayServices()
       const signInResponse = await GoogleSignin.signIn()
       if (!signInResponse.data) {
         throw new AuthError('User not found', 'USER_NOT_FOUND')
       }
-      const { accessToken } = await GoogleSignin.getTokens()
+      const { accessToken, idToken } = await GoogleSignin.getTokens()
       return {
         accessToken,
+        idToken,
         user: signInResponse.data,
       }
     } catch (error) {

--- a/packages/mobile/testing/__tests__/auth/googleAuth.test.ts
+++ b/packages/mobile/testing/__tests__/auth/googleAuth.test.ts
@@ -37,6 +37,7 @@ describe('Google authentication unit tests', () => {
     const result = await googleAuth.signIn()
     expect(result).toEqual({
       accessToken: 'mock-access-token',
+      idToken: 'mock-id-token',
       user: {
         email: 'mocked-email@example.com',
         name: 'Test user',

--- a/packages/mobile/testing/__tests__/sdk/mobileClient.test.ts
+++ b/packages/mobile/testing/__tests__/sdk/mobileClient.test.ts
@@ -131,6 +131,7 @@ describe('MobileClient', () => {
           getAccessToken: (oldAccessToken: string) => Promise<string>
           signInSilently: () => Promise<{
             accessToken: string
+            idToken: string
             user: unknown
           }>
         }
@@ -172,6 +173,7 @@ describe('MobileClient', () => {
           getAccessToken: (oldAccessToken: string) => Promise<string>
           signInSilently: () => Promise<{
             accessToken: string
+            idToken: string
             user: unknown
           }>
         }
@@ -188,6 +190,7 @@ describe('MobileClient', () => {
         .spyOn(internalClient.authenticationManager, 'signInSilently')
         .mockResolvedValueOnce({
           accessToken: 'silent-access-token',
+          idToken: 'silent-id-token',
           user: undefined,
         })
       const getAccessTokenFromClientSpy = jest


### PR DESCRIPTION
- Extend IAuthentication and ISDKFacade to include idToken
- Extension: map id_token from the token exchange; silent refresh returns an empty idToken
- Mobile: include idToken from GoogleSignin.getTokens()